### PR TITLE
[WIP] Dump necessary session information to debug for Wireshark.

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -951,14 +951,26 @@ ssh_set_newkeys(struct ssh *ssh, int mode)
 		
 		struct sshenc s0 = ssh->state->newkeys[0]->enc;
 		struct sshenc s1 = ssh->state->newkeys[1]->enc;
-		printf("\n\nkey0:\n");
-		sshbuf_dump_data(s0.key, s0.key_len, stdout);
-		printf("\niv0:\n");
-		sshbuf_dump_data(s0.iv, s0.iv_len, stdout);
-		printf("\n\nkey1:\n");
-		sshbuf_dump_data(s1.key, s1.key_len, stdout);
-		printf("\niv1:\n");
-		sshbuf_dump_data(s1.iv, s1.iv_len, stdout);
+		
+		// WIRESHARK: DUMP
+		int i;
+		int len0 = (int) s0.key_len;
+		int len1 = (int) s1.key_len;
+
+		debug("DUMP|KEY_LEN_0=%u|%i", s0.key_len, len0);
+		debug("DUMP|KEY_LEN_1=%u|%i", s1.key_len, len1);
+
+		char chars[s0.key_len * 2 + 5];
+		for (i = 0; i < len0; i += 1) {
+			sprintf((char*) chars + (2 * i), "%02x", s0.key[i]);
+		}
+		debug("DUMP|KEY_DUMP_0=%s", chars);
+		
+		char chars1[s1.key_len * 2 + 5];
+		for (i = 0; i < len1; i += 1) {
+			sprintf((char*)  (chars1 + (2 * i)), "%02x", s1.key[i]);
+		}
+		debug("DUMP|KEY_DUMP_1=%s", chars1);
 	}
 
 	return 0;


### PR DESCRIPTION
Dumps the following to `debug1` to allow "Wireshark" (currently our python script) to decrypt packets:
- Session keys (both `key0` and `key1`)
- Individual packet state (eventually should be replaced by Wireshark state information)